### PR TITLE
always specify return-type of api-calls

### DIFF
--- a/templates/default/procedure-call.eta
+++ b/templates/default/procedure-call.eta
@@ -65,8 +65,6 @@ const responseFormatTmpl = responseContentKind[responseBodyInfo.success && respo
 const securityTmpl = security ? 'true' : null;
 
 const describeReturnType = () => {
-    if (!config.toJS) return "";
-
     switch(config.httpClientType) {
         case HTTP_CLIENT.AXIOS: {
           return `Promise<AxiosResponse<${type}>>`
@@ -86,7 +84,7 @@ const describeReturnType = () => {
 <%~ routeDocs.lines %>
 
  */
-<%~ route.routeName.usage %><%~ route.namespace ? ': ' : ' = ' %>(<%~ wrapperArgs %>)<%~ config.toJS ? `: ${describeReturnType()}` : "" %> =>
+<%~ route.routeName.usage %><%~ route.namespace ? ': ' : ' = ' %>(<%~ wrapperArgs %>): <%~ describeReturnType() %> =>
     <%~ config.singleHttpClient ? 'this.http.request' : 'this.request' %><<%~ type %>, <%~ errorType %>>({
         path: `<%~ path %>`,
         method: '<%~ _.upperCase(method) %>',

--- a/templates/default/procedure-call.eta
+++ b/templates/default/procedure-call.eta
@@ -70,7 +70,11 @@ const describeReturnType = () => {
           return `Promise<AxiosResponse<${type}>>`
         }
         default: {
-          return `Promise<HttpResponse<${type}, ${errorType}>>`
+          if(config.unwrapResponseData) {
+            return `Promise<${type}>`
+          } else {
+            return `Promise<HttpResponse<${type}, ${errorType}>>`
+          }
         }
     }
 }

--- a/templates/default/procedure-call.eta
+++ b/templates/default/procedure-call.eta
@@ -70,7 +70,7 @@ const describeReturnType = () => {
           return `Promise<AxiosResponse<${type}>>`
         }
         default: {
-          return `Promise<HttpResponse<${type}, ${errorType}>`
+          return `Promise<HttpResponse<${type}, ${errorType}>>`
         }
     }
 }


### PR DESCRIPTION
currently, the response-type of the data-attribute of the response of an api-call has to be deduced by following the lambda to the parametrized request function and evaluating it return type. This confuses the JetBrains (ie. IntelliJ / WebStorm) language server and it can't deduce the return-type of an await or then-statement correctly. I'm not sure if the VSCode language server handles this better, but I would expect it to have similar problems.

By specifying the return-type explicitly, the language-servers can easily deduce the type of the response.
